### PR TITLE
Add GitHub actions to build next image and validate PRs

### DIFF
--- a/.github/workflows/dockerimage-next.yml
+++ b/.github/workflows/dockerimage-next.yml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Next Dockerimage
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    -
+      name: Checkout devworkspace-operator source code
+      uses: actions/checkout@v2
+    -
+      name: Compile che-api-sidecar
+      run: ./docker-compile.sh
+    -
+      name: Docker Build & Push
+      uses: docker/build-push-action@v1.1.0
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+        repository: che-incubator/che-api-sidecar
+        dockerfile: ./src/main/docker/Dockerfile
+        tags: next
+        tag_with_sha: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: Validate PRs
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  docker:
+    name: Check docker build
+    runs-on: ubuntu-18.04
+    steps:
+    -
+      name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+    -
+      name: Build che api sidecar dockerimage
+      run: ./docker-build.sh

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -14,17 +14,10 @@
 # Parameters:
 #   $1 - docker tag used for final image
 
-DEFAULT_TAG="che-rest-apis"
+DEFAULT_TAG="che-api-sidecar:local"
 FINAL_TAG=${1:-$DEFAULT_TAG}
-echo "Building image using tag $FINAL_TAG"
 
-echo "Building che-rest-apis native binary in container"
-docker build --ulimit nofile=122880:122880 -m 5G -t che-rest-apis-builder -f build.Dockerfile .
+./docker-compile.sh
 
-echo "Copying binary to ./target"
-docker create --name builder che-rest-apis-builder
-docker cp builder:/usr/src/app/target ./target/
-docker rm builder
-
-echo "Building che-rest-apis image"
+echo "Building che-rest-apis image using tag $FINAL_TAG"
 docker build -t $FINAL_TAG -f ./src/main/docker/Dockerfile .

--- a/docker-compile.sh
+++ b/docker-compile.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+# A script to autmate compiling of the che-rest-apis
+
+echo "Compiling che-rest-apis native binary in container"
+docker build --ulimit nofile=122880:122880 -m 5G -t che-api-sidecar-builder -f build.Dockerfile .
+
+echo "Copying binary to ./target"
+docker create --name builder che-api-sidecar-builder
+docker cp builder:/usr/src/app/target ./target/
+docker rm builder


### PR DESCRIPTION
### What does this PR do?
Adds GitHub actions 

### Which issue does this PR reference?
https://github.com/eclipse/che/issues/16636

### How this PR is tested?
https://quay.io/repository/che-incubator/che-api-sidecar?tab=tags are built via https://github.com/che-incubator/che-api-sidecar/pull/3/checks?check_run_id=1002401202

PR check job could be verified at the bottom of the PR.

### What could be done better?
1. We could set up docker images layers caches but I don't think that it's critical since there are no frequent changes in that repo.